### PR TITLE
Fix #27, attributes search should support reg. expressions...

### DIFF
--- a/liveattrs/db/qbuilder/args.go
+++ b/liveattrs/db/qbuilder/args.go
@@ -94,7 +94,7 @@ func (args *AttrArgs) ExportSQL(itemPrefix, corpusID string) (string, []string) 
 			cnfItem = append(
 				cnfItem,
 				fmt.Sprintf(
-					"%s.%s LIKE ?",
+					"%s.%s REGEXP ?",
 					itemPrefix, key),
 			)
 			sqlValues = append(sqlValues, args.importValue(tValues))


### PR DESCRIPTION
... to match patterns generated by KonText's calendar widget