### PR TITLE
Fix - incorrect table name for aligned  corpora

### DIFF
--- a/liveattrs/db/qbuilder/adhoc/adhoc.go
+++ b/liveattrs/db/qbuilder/adhoc/adhoc.go
@@ -49,7 +49,7 @@ func (ssize *SubcSize) Query() (ansSQL string, whereValues []any) {
 			joinSQL,
 			fmt.Sprintf(
 				"JOIN `%s_liveattrs_entry` AS t%d ON t1.item_id = t%d.item_id",
-				ssize.CorpusInfo.Name, iOffs, iOffs,
+				ssize.CorpusInfo.GroupedName(), iOffs, iOffs,
 			),
 		)
 		whereSQL = append(


### PR DESCRIPTION
(this was caused by the fix 5580f709fe98 which was, apart from this issue, correct