### PR TITLE
Allow setting a cutoff in auto-complete endpoint ...

### DIFF
--- a/liveattrs/request/query/query.go
+++ b/liveattrs/request/query/query.go
@@ -93,4 +93,9 @@ type Payload struct {
 	Attrs            Attrs    `json:"attrs"`
 	AutocompleteAttr string   `json:"autocompleteAttr"`
 	MaxAttrListSize  int      `json:"maxAttrListSize"`
+
+	// ApplyCutoff, if set true, then in case a result returns more than MaxAttrListSize,
+	// the list is cut to the MaxAttrListSize and the response is behaving like there
+	// is no problem with too much matching items
+	ApplyCutoff bool `json:"applyCutoff"`
 }


### PR DESCRIPTION
... to avoid no-data listing for long lists.

Plus fix - incorrect cmp with maxAttrListSize in ExportAttrValues