### PR TITLE
Fix - missing way how to conf tagset for "aliased" corpora proc.

### DIFF
--- a/cncdb/cncdb.go
+++ b/cncdb/cncdb.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"masm/v3/corpus"
+	"masm/v3/liveattrs/qs"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -192,7 +193,7 @@ func (c *CNCMySQLHandler) GetSimpleQueryDefaultAttrs(corpusID string) ([]string,
 	return attrs, nil
 }
 
-func (c *CNCMySQLHandler) GetCorpusTagsets(corpusID string) ([]string, error) {
+func (c *CNCMySQLHandler) GetCorpusTagsets(corpusID string) ([]qs.SupportedTagset, error) {
 	rows, err := c.conn.Query(
 		"SELECT tagset_name FROM corpus_tagset WHERE corpus_name = ?",
 		corpusID,
@@ -200,14 +201,14 @@ func (c *CNCMySQLHandler) GetCorpusTagsets(corpusID string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get corpus tagsets: %w", err)
 	}
-	ans := make([]string, 0, 5)
+	ans := make([]qs.SupportedTagset, 0, 5)
 	var val string
 	for rows.Next() {
 		err := rows.Scan(&val)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get corpus tagsets: %w", err)
 		}
-		ans = append(ans, val)
+		ans = append(ans, qs.SupportedTagset(val))
 	}
 	return ans, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/czcorpus/cnc-gokit v0.11.0
+	github.com/czcorpus/cnc-gokit v0.11.2
 	github.com/czcorpus/manabuild v0.1.3
 	github.com/czcorpus/rexplorer v0.0.2
 	github.com/czcorpus/vert-tagextract/v3 v3.0.6

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJ
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/czcorpus/cnc-gokit v0.11.0 h1:0DSWVAMu6TyBLxeBfTRB/yezoFKQPy1zW8yqUJmcBzg=
-github.com/czcorpus/cnc-gokit v0.11.0/go.mod h1:BZSRrYUFIHXVIiuqnSoZbfXfL2X/gHWG3w35aIVW36U=
+github.com/czcorpus/cnc-gokit v0.11.2 h1:XlU6oZENE1BEOwJZMZ/C7hv3aK1EFP/1NDqukcVaCJI=
+github.com/czcorpus/cnc-gokit v0.11.2/go.mod h1:BZSRrYUFIHXVIiuqnSoZbfXfL2X/gHWG3w35aIVW36U=
 github.com/czcorpus/manabuild v0.1.3 h1:dcTMpRtUUHhm1H+7532MeNFID0WyRVDorydROgbbo4w=
 github.com/czcorpus/manabuild v0.1.3/go.mod h1:dj2iAsZObs4yJhF6KkQs5oH2AAyZlrmaNwMGV44hLbk=
 github.com/czcorpus/rexplorer v0.0.2 h1:e8DuZGX/CYXv3Y2ovhMvntXH6QgAgQ3droZV+1w153k=

--- a/liveattrs/qs/cminfer.go
+++ b/liveattrs/qs/cminfer.go
@@ -39,6 +39,10 @@ func (st SupportedTagset) Validate() error {
 	return fmt.Errorf("invalid tagset type: %s", st)
 }
 
+func (st SupportedTagset) String() string {
+	return string(st)
+}
+
 const (
 	TagsetCSCNC2000SPK SupportedTagset = "cs_cnc2000_spk"
 	TagsetCSCNC2000    SupportedTagset = "cs_cnc2000"


### PR DESCRIPTION
(e.g. when we need to create tables for syn_v13 along with actual existing liveattrs tables liveattrs_syn_v13 by defining a "virtual" corpus "syn_v13_1g")